### PR TITLE
fix: reorder getCloudflareContext() before getAuth()

### DIFF
--- a/laprogram/app/api/admin/flag/[key]/route.ts
+++ b/laprogram/app/api/admin/flag/[key]/route.ts
@@ -6,6 +6,8 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ key: string }> },
 ) {
+  const { env } = await getCloudflareContext({ async: true });
+
   const auth = await getAuth();
   const session = await auth.api.getSession({
     headers: await headers(),
@@ -22,7 +24,6 @@ export async function POST(
   }
 
   const body = await request.text();
-  const { env } = await getCloudflareContext({ async: true });
   await env.config.put(key, body);
 
   return new Response(null, { status: 200 });

--- a/laprogram/app/api/availability/route.ts
+++ b/laprogram/app/api/availability/route.ts
@@ -14,6 +14,8 @@ interface AvailabilityPayload {
 
 export async function POST(request: Request) {
   try {
+    const { env } = await getCloudflareContext({ async: true });
+
     const auth = await getAuth();
     const session = await auth.api.getSession({
       headers: await headers(),
@@ -23,7 +25,6 @@ export async function POST(request: Request) {
       return new Response("Unauthenticated user.", { status: 401 });
     }
 
-    const { env } = await getCloudflareContext({ async: true });
     const db = env.data;
     const userId = session.user.id;
 
@@ -74,6 +75,8 @@ export async function POST(request: Request) {
 
 export async function GET(request: Request) {
   try {
+    const { env } = await getCloudflareContext({ async: true });
+
     const auth = await getAuth();
     const session = await auth.api.getSession({
       headers: await headers(),
@@ -83,7 +86,6 @@ export async function GET(request: Request) {
       return new Response("Unauthenticated user.", { status: 401 });
     }
 
-    const { env } = await getCloudflareContext({ async: true });
     const db = env.data;
     const userId = session.user.id;
 

--- a/laprogram/app/api/feedback/route.ts
+++ b/laprogram/app/api/feedback/route.ts
@@ -44,18 +44,19 @@ export async function POST(request: Request) {
 }
 
 export async function GET() {
-  const auth = await getAuth();
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-
-  if (!session) {
-    return new Response("Unauthenticated user.", { status: 401 });
-  }
-
-  let rows;
   try {
     const { env } = getCloudflareContext();
+
+    const auth = await getAuth();
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session) {
+      return new Response("Unauthenticated user.", { status: 401 });
+    }
+
+    let rows;
     const result = await env.data
       ?.prepare(`SELECT id, feedback FROM feedback WHERE recipientId = ?1`)
       .bind(session.user.id)
@@ -65,16 +66,16 @@ export async function GET() {
       return new Response("Encountered database error.", { status: 500 });
     }
     rows = result.results;
+
+    const sorted = sortBy(rows, (r) => r.id);
+
+    const safe = sorted.flatMap((r) => {
+      const parsed = anonFeedbackSchema.safeParse(JSON.parse(r.feedback));
+      return parsed.success ? [parsed.data] : [];
+    });
+
+    return new Response(JSON.stringify(safe), { status: 200 });
   } catch {
     return new Response("Encountered database error.", { status: 500 });
   }
-
-  const sorted = sortBy(rows, (r) => r.id);
-
-  const safe = sorted.flatMap((r) => {
-    const parsed = anonFeedbackSchema.safeParse(JSON.parse(r.feedback));
-    return parsed.success ? [parsed.data] : [];
-  });
-
-  return new Response(JSON.stringify(safe), { status: 200 });
 }

--- a/laprogram/app/api/la/self/route.ts
+++ b/laprogram/app/api/la/self/route.ts
@@ -4,17 +4,17 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { headers } from "next/headers";
 
 export async function GET() {
-  const auth = await getAuth();
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-
-  if (!session) {
-    return new Response("Unauthenticated user.", { status: 401 });
-  }
-
   try {
     const { env } = getCloudflareContext();
+    const auth = await getAuth();
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session) {
+      return new Response("Unauthenticated user.", { status: 401 });
+    }
+
     const result = await env.data
       ?.prepare(
         `SELECT course_name, position

--- a/laprogram/app/api/observation/[id]/route.ts
+++ b/laprogram/app/api/observation/[id]/route.ts
@@ -4,9 +4,11 @@ import { headers } from "next/headers";
 
 export async function DELETE(
   request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    const { env } = await getCloudflareContext({ async: true });
+
     const auth = await getAuth();
     const session = await auth.api.getSession({
       headers: await headers(),
@@ -17,12 +19,11 @@ export async function DELETE(
     }
 
     const { id } = await params;
-    const { env } = await getCloudflareContext({ async: true });
     const db = env.data;
 
     const observation = await db
       .prepare(
-        "SELECT id, observer_id, observee_id, availability_id FROM observation WHERE id = ?"
+        "SELECT id, observer_id, observee_id, availability_id FROM observation WHERE id = ?",
       )
       .bind(id)
       .first<{
@@ -49,7 +50,7 @@ export async function DELETE(
         .bind(observation.availability_id),
       db
         .prepare(
-          "UPDATE availability SET status = 'open' WHERE la_id = ? AND status = 'hidden'"
+          "UPDATE availability SET status = 'open' WHERE la_id = ? AND status = 'hidden'",
         )
         .bind(observation.observee_id),
     ]);

--- a/laprogram/app/api/observation/open/route.ts
+++ b/laprogram/app/api/observation/open/route.ts
@@ -5,6 +5,8 @@ import { Availability } from "@/types/db";
 
 export async function GET() {
   try {
+    const { env } = await getCloudflareContext({ async: true });
+
     const auth = await getAuth();
     const session = await auth.api.getSession({
       headers: await headers(),
@@ -12,7 +14,6 @@ export async function GET() {
     if (!session) {
       return new Response("Unauthenticated user.", { status: 401 });
     }
-    const { env } = await getCloudflareContext({ async: true });
     const result = await env.data
       .prepare(
         `SELECT user.name AS la_name,

--- a/laprogram/app/api/observation/route.ts
+++ b/laprogram/app/api/observation/route.ts
@@ -4,6 +4,8 @@ import { headers } from "next/headers";
 
 export async function POST(request: Request) {
   try {
+    const { env } = await getCloudflareContext({ async: true });
+
     const auth = await getAuth();
     const session = await auth.api.getSession({
       headers: await headers(),
@@ -13,7 +15,6 @@ export async function POST(request: Request) {
       return new Response("Unauthenticated user.", { status: 401 });
     }
 
-    const { env } = await getCloudflareContext({ async: true });
     const db = env.data;
     const observerId = session.user.id;
 
@@ -27,10 +28,16 @@ export async function POST(request: Request) {
 
     const slot = await db
       .prepare(
-        "SELECT id, la_id, section_id, time, week FROM availability WHERE id = ? AND status = 'open'"
+        "SELECT id, la_id, section_id, time, week FROM availability WHERE id = ? AND status = 'open'",
       )
       .bind(availability_id)
-      .first<{ id: string; la_id: string; section_id: string; time: string; week: string }>();
+      .first<{
+        id: string;
+        la_id: string;
+        section_id: string;
+        time: string;
+        week: string;
+      }>();
 
     if (!slot) {
       return new Response("Slot not found or not available", { status: 404 });
@@ -45,7 +52,7 @@ export async function POST(request: Request) {
     await db.batch([
       db
         .prepare(
-          "INSERT INTO observation (id, observer_id, observee_id, availability_id) VALUES (?, ?, ?, ?)"
+          "INSERT INTO observation (id, observer_id, observee_id, availability_id) VALUES (?, ?, ?, ?)",
         )
         .bind(observationId, observerId, slot.la_id, availability_id),
       db
@@ -53,14 +60,14 @@ export async function POST(request: Request) {
         .bind(availability_id),
       db
         .prepare(
-          "UPDATE availability SET status = 'hidden' WHERE la_id = ? AND status = 'open'"
+          "UPDATE availability SET status = 'hidden' WHERE la_id = ? AND status = 'open'",
         )
         .bind(slot.la_id),
     ]);
 
     const openCount = await db
       .prepare(
-        "SELECT COUNT(*) as count FROM availability WHERE la_id = ? AND status = 'open'"
+        "SELECT COUNT(*) as count FROM availability WHERE la_id = ? AND status = 'open'",
       )
       .bind(slot.la_id)
       .first<{ count: number }>();
@@ -68,7 +75,7 @@ export async function POST(request: Request) {
     if (openCount && openCount.count === 0) {
       await db
         .prepare(
-          "UPDATE availability SET status = 'open' WHERE la_id = ? AND status = 'hidden'"
+          "UPDATE availability SET status = 'open' WHERE la_id = ? AND status = 'hidden'",
         )
         .bind(slot.la_id)
         .run();
@@ -85,6 +92,8 @@ export async function POST(request: Request) {
 
 export async function GET() {
   try {
+    const { env } = await getCloudflareContext({ async: true });
+
     const auth = await getAuth();
     const session = await auth.api.getSession({
       headers: await headers(),
@@ -94,7 +103,6 @@ export async function GET() {
       return new Response("Unauthenticated user.", { status: 401 });
     }
 
-    const { env } = await getCloudflareContext({ async: true });
     const db = env.data;
 
     const result = await db
@@ -113,7 +121,7 @@ export async function GET() {
         JOIN availability ON observation.availability_id = availability.id
         JOIN section ON availability.section_id = section.id
         JOIN user ON observation.observee_id = user.id
-        WHERE observation.observer_id = ?`
+        WHERE observation.observer_id = ?`,
       )
       .bind(session.user.id)
       .all();

--- a/laprogram/app/api/sections/route.ts
+++ b/laprogram/app/api/sections/route.ts
@@ -4,6 +4,8 @@ import { headers } from "next/headers";
 
 export async function GET() {
   try {
+    const { env } = await getCloudflareContext({ async: true });
+
     const auth = await getAuth();
     const session = await auth.api.getSession({
       headers: await headers(),
@@ -13,7 +15,6 @@ export async function GET() {
       return new Response("Unauthenticated user.", { status: 401 });
     }
 
-    const { env } = await getCloudflareContext({ async: true });
     const db = env.data;
 
     const result = await db

--- a/laprogram/app/api/settings/avatar/route.ts
+++ b/laprogram/app/api/settings/avatar/route.ts
@@ -7,32 +7,32 @@ const MAX_SIZE = 2 * 1024 * 1024; // 2 MB
 const ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 
 export async function POST(request: Request) {
-  const auth = await getAuth();
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-
-  if (!session) {
-    return new Response("Unauthenticated user.", { status: 401 });
-  }
-
-  const formData = await request.formData();
-  const file = formData.get("file");
-
-  if (!(file instanceof File)) {
-    return new Response("No file provided.", { status: 400 });
-  }
-
-  if (!ALLOWED_TYPES.has(file.type)) {
-    return new Response("File must be JPEG, PNG, or WebP.", { status: 400 });
-  }
-
-  if (file.size > MAX_SIZE) {
-    return new Response("File must be under 2 MB.", { status: 400 });
-  }
-
   try {
     const { env } = getCloudflareContext();
+
+    const auth = await getAuth();
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session) {
+      return new Response("Unauthenticated user.", { status: 401 });
+    }
+
+    const formData = await request.formData();
+    const file = formData.get("file");
+
+    if (!(file instanceof File)) {
+      return new Response("No file provided.", { status: 400 });
+    }
+
+    if (!ALLOWED_TYPES.has(file.type)) {
+      return new Response("File must be JPEG, PNG, or WebP.", { status: 400 });
+    }
+
+    if (file.size > MAX_SIZE) {
+      return new Response("File must be under 2 MB.", { status: 400 });
+    }
 
     const transformedImage = (
       await env.IMAGES?.input(file.stream())


### PR DESCRIPTION
Fixes error of not finding request context when running certain APIs

tldr: the error is that `getAuth()` needs a request context.`getCloudflareContext`, as a by-product, forces this context to be fully initialized. The reason why this is needed only sometimes. Whenever a worker cold starts, the first API it calls will basically fail because this context is not initialized. Every future API call uses some cached state from previous invocations (also explains why it happens once every so often at every cold start of a new worker).